### PR TITLE
Add AgentReacher social media skills

### DIFF
--- a/skills/agentreacher/skills/cadence-planner/SKILL.md
+++ b/skills/agentreacher/skills/cadence-planner/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: cadence-planner
+description: Choose a practical social media posting cadence by channel, campaign period, audience, available assets, and review capacity. Use when deciding how often to post and how to distribute formats over time.
+tags:
+  - social-media
+  - cadence
+  - scheduling
+  - agentreacher-compatible
+---
+
+# Cadence Planner
+
+Set a realistic publishing rhythm. The cadence should be ambitious enough to learn, but light enough to maintain quality and approvals.
+
+## Inputs
+
+- channels
+- period length
+- campaign goal
+- team capacity
+- asset availability
+- approval process
+- minimum and maximum posting frequency
+- time zone or audience geography
+
+## Workflow
+
+1. Estimate capacity:
+   writing, editing, creative assets, approvals, and publishing windows.
+
+2. Choose a channel mix:
+   primary channels get original posts; secondary channels get adapted or lighter posts.
+
+3. Assign weekly frequency:
+   split by platform, format, and pillar.
+
+4. Add time slots:
+   use sensible daypart assumptions and mark them as adjustable if no data is available.
+
+5. Add constraints:
+   rest days, approval cutoff, asset deadlines, and launch-day exceptions.
+
+## Taste Rules
+
+- Fewer high-quality posts beat a brittle high-volume plan.
+- Cadence should match the buyer journey and platform norms.
+- Do not recommend video frequency unless there is production capacity.
+- Treat launches differently from evergreen periods.
+- State assumptions instead of pretending to know best posting times.
+
+## Output Format
+
+```md
+## Recommended Cadence
+| Platform | Weekly Posts | Formats | Role | Notes |
+| --- | --- | --- | --- | --- |
+
+## Weekly Rhythm
+| Day | Platform | Post Type | Time Window | Approval Cutoff |
+| --- | --- | --- | --- | --- |
+
+## Assumptions
+- [assumption]
+```
+
+## AgentReacher Notes
+
+Use this before AgentReacher scheduling to decide how many posts the agent should create and where the calendar needs human review.
+
+Example usage in AgentReacher: "Plan a realistic 6-week cadence for X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Pinterest, Threads, and Bluesky with two hours of review time per week."

--- a/skills/agentreacher/skills/cadence-planner/agents/openai.yaml
+++ b/skills/agentreacher/skills/cadence-planner/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Cadence Planner"
+  short_description: "Choose a practical posting rhythm"
+  default_prompt: "Use $cadence-planner to choose a practical posting cadence for these channels."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/calendar-builder/SKILL.md
+++ b/skills/agentreacher/skills/calendar-builder/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: calendar-builder
+description: Build a complete social media publishing calendar from a campaign goal, date range, audience, channels, and content constraints. Use when planning a week, month, launch window, or ongoing period of scheduled content.
+tags:
+  - social-media
+  - calendar
+  - campaign-planning
+  - agentreacher-compatible
+---
+
+# Calendar Builder
+
+Turn strategy and draft ideas into a scheduling-ready content calendar. Optimize for sequence, channel fit, and sustainable cadence, not maximum volume.
+
+## Inputs
+
+- date range or number of weeks
+- campaign goal
+- audience
+- channels
+- content pillars or themes
+- existing assets
+- constraints: approval windows, excluded dates, time zones, required CTAs
+
+If cadence is missing, choose a conservative default and state it.
+
+## Workflow
+
+1. Define the campaign arc:
+   introduce the problem, teach the method, show proof, handle objections, repeat the CTA.
+
+2. Allocate posts across pillars:
+   avoid clustering too many sales, proof, or education posts together.
+
+3. Choose platform-specific slots:
+   assign date, time, platform, angle, format, CTA, asset, and approval status.
+
+4. Add sequence logic:
+   note which posts depend on earlier posts and which can stand alone.
+
+5. Mark gaps:
+   list missing assets, claims needing verification, and posts that need human review.
+
+## Taste Rules
+
+- A calendar should feel intentional when read week by week.
+- Do not fill every empty slot just because the period is long.
+- Keep each post's job clear: awareness, education, proof, objection, conversion, or community.
+- Avoid repeating the same CTA on consecutive posts unless it is launch day.
+- Include evergreen fallback posts for risky or asset-dependent slots.
+
+## Output Format
+
+```md
+## Calendar Strategy
+- Period:
+- Goal:
+- Cadence:
+- Primary CTA:
+
+## Publishing Calendar
+| Date | Time | Platform | Pillar | Angle | Format | CTA | Asset | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Sequence Notes
+- [dependency or rationale]
+
+## Missing Inputs
+- [asset, claim, approval, or scheduling constraint]
+```
+
+## AgentReacher Notes
+
+Designed to work well before AgentReacher scheduling. The table can be turned into posts, review tasks, or scheduled drafts.
+
+Example usage in AgentReacher: "Build a 30-day calendar for our AgentReacher launch across X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Pinterest, Threads, and Bluesky."

--- a/skills/agentreacher/skills/calendar-builder/agents/openai.yaml
+++ b/skills/agentreacher/skills/calendar-builder/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Calendar Builder"
+  short_description: "Plan a scheduling-ready campaign calendar"
+  default_prompt: "Use $calendar-builder to create a scheduling-ready social calendar for this campaign."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/content-pillars/SKILL.md
+++ b/skills/agentreacher/skills/content-pillars/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: content-pillars
+description: Define reusable social media content pillars for a product, founder, brand, or campaign. Use when a content calendar needs durable themes, repeatable post types, and clearer editorial direction.
+tags:
+  - social-media
+  - content-strategy
+  - positioning
+  - agentreacher-compatible
+---
+
+# Content Pillars
+
+Create the repeatable themes that make a social calendar coherent over time. Pillars should guide what to post, what not to post, and how each idea earns attention.
+
+## Inputs
+
+- product, brand, or founder
+- audience
+- goal
+- category or market
+- proof points
+- preferred channels
+- topics to avoid
+
+## Workflow
+
+1. Extract the audience tensions:
+   pains, ambitions, objections, status anxieties, and buying triggers.
+
+2. Define 4-7 pillars:
+   each pillar needs a name, purpose, audience question, post formats, proof source, and example angles.
+
+3. Balance the mix:
+   include education, belief, proof, product, objection, and community where relevant.
+
+4. Add boundaries:
+   say what does not belong in each pillar so the calendar does not drift.
+
+5. Recommend a pillar ratio:
+   percentage or weekly count by pillar for the next campaign period.
+
+## Taste Rules
+
+- Pillars are not vague categories like "thought leadership".
+- Each pillar should generate at least 10 real post ideas.
+- Product pillars need proof or workflow detail, not feature lists.
+- Founder pillars need specific experience, not generic lessons.
+- Leave room for timely posts without making the calendar reactive.
+
+## Output Format
+
+```md
+## Pillar System
+| Pillar | Purpose | Audience Question | Formats | Proof Source | Ratio |
+| --- | --- | --- | --- | --- | --- |
+
+## Example Angles
+### [Pillar]
+- [post angle]
+
+## Boundaries
+- [what to avoid]
+```
+
+## AgentReacher Notes
+
+Use this before building an AgentReacher calendar so scheduled posts are organized by durable campaign themes instead of isolated ideas.
+
+Example usage in AgentReacher: "Create content pillars for AgentReacher targeting AI founders and solo SaaS builders."

--- a/skills/agentreacher/skills/content-pillars/agents/openai.yaml
+++ b/skills/agentreacher/skills/content-pillars/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Content Pillars"
+  short_description: "Define repeatable campaign themes"
+  default_prompt: "Use $content-pillars to define reusable social media pillars for this brand."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/positioning/SKILL.md
+++ b/skills/agentreacher/skills/positioning/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: positioning
+description: Analyze competing products and turn the market gap into credible positioning, messaging angles, and social campaign claims. Use when comparing competitors, writing alternative pages, sharpening product positioning, or planning campaigns against a category narrative.
+tags:
+  - positioning
+  - social-media
+  - competitor-analysis
+  - agentreacher-compatible
+---
+
+# Positioning
+
+Find the strongest credible contrast between a product and its alternatives. The output should help social content, landing pages, sales notes, and launch campaigns without sounding petty or inflated.
+
+## Inputs
+
+- product being positioned
+- target customer
+- competitors or alternatives
+- category frame
+- current positioning
+- proof points
+- known weaknesses or constraints
+- claims that must be avoided
+
+If competitor data may be current or factual, verify it with primary sources or ask for source material. Do not invent pricing, feature support, customer counts, integrations, security claims, or roadmap details.
+
+## Positioning Lenses
+
+- workflow: what users must do manually
+- speed: time-to-value and operational overhead
+- control: review, approval, governance, safety
+- channel fit: native posting vs generic publishing
+- audience: who each product is really built for
+- integration: where the tool sits in the user's stack
+- taste: quality of output, not just quantity
+- risk: compliance, brand safety, missed context
+
+## Workflow
+
+1. Build the landscape:
+   direct competitors, adjacent tools, status quo alternatives, and "do nothing".
+
+2. Create a comparison matrix:
+   audience, primary job-to-be-done, strengths, tradeoffs, credible contrast, and proof needed.
+
+3. Identify the wedge:
+   underserved audience, workflow gap, market change, new behavior, or category assumption worth challenging.
+
+4. Write positioning angles:
+   one category sentence, three contrast statements, three campaign angles, three "not for you if..." boundaries, and three proof assets to collect.
+
+5. Convert into social campaign material:
+   X thread angle, LinkedIn founder post angle, short-form video angle, alternative-page headline, and objection-handling post.
+
+## Taste Rules
+
+- Critique workflows, not people.
+- Prefer "built for X, unlike tools optimized for Y" over "we are better than Y."
+- Name competitors only when the comparison is factual, useful, and defensible.
+- Strong positioning includes tradeoffs. Say who the product is not for.
+- Never fabricate competitor limitations. Mark uncertain claims as "needs verification."
+
+## Output Format
+
+```md
+## Landscape
+| Alternative | Best for | Strength | Tradeoff | Verification Needed |
+| --- | --- | --- | --- | --- |
+## Positioning Wedge
+[one paragraph]
+## Messaging
+- Category sentence:
+- Contrast statement 1:
+- Contrast statement 2:
+- Contrast statement 3:
+- Not for you if:
+## Social Campaign Angles
+1. [angle]
+   Platform fit:
+   Proof needed:
+## Claims To Verify
+- [claim]
+```
+
+## AgentReacher Notes
+
+Optimized for AI startups, SaaS founders, agentic tooling, and social automation products like AgentReacher. It works best when used before campaign generation so the content calendar is built around a clear wedge instead of generic feature announcements.
+
+Example usage in AgentReacher: "Position AgentReacher against Buffer, Hootsuite, and Postiz for AI founders who want agents to schedule posts directly from their workflow."

--- a/skills/agentreacher/skills/positioning/agents/openai.yaml
+++ b/skills/agentreacher/skills/positioning/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Positioning"
+  short_description: "Find a credible market wedge"
+  default_prompt: "Use $positioning to compare these alternatives and turn the gap into campaign-ready positioning."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/post-packager/SKILL.md
+++ b/skills/agentreacher/skills/post-packager/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: post-packager
+description: Convert social media drafts into an approval-ready scheduling package with platform, copy, timing, assets, CTA, and review notes. Use when preparing posts for scheduling, review, or handoff.
+tags:
+  - social-media
+  - approvals
+  - scheduling
+  - agentreacher-compatible
+---
+
+# Post Packager
+
+Turn drafts into a clean handoff package. Every post should be ready to approve, revise, or schedule without hunting for context.
+
+## Inputs
+
+- drafts or post ideas
+- platforms
+- planned dates and times
+- assets
+- CTA
+- approval owner
+- campaign or pillar
+- claims requiring review
+
+## Workflow
+
+1. Normalize each post:
+   platform, copy, scheduled time, asset, CTA, status, and owner.
+
+2. Validate platform fit:
+   length, formatting, tone, media assumptions, and CTA intensity.
+
+3. Flag risks:
+   unsupported claims, missing visuals, duplicate copy, sensitive wording, or weak hooks.
+
+4. Add approval status:
+   ready, needs edit, needs asset, needs legal/fact check, or blocked.
+
+5. Produce final package:
+   table first, then post-by-post copy blocks.
+
+## Taste Rules
+
+- Do not silently rewrite approved copy unless asked.
+- Keep review notes concrete and actionable.
+- Separate missing assets from copy problems.
+- Preserve platform-native formatting.
+- Make the package easy to paste into scheduling tools or agent workflows.
+
+## Output Format
+
+```md
+## Scheduling Package
+| ID | Date | Time | Platform | Status | Asset | CTA | Review Note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Final Copy
+### [ID] [Platform]
+[copy]
+
+## Blockers
+- [missing input or risk]
+```
+
+## AgentReacher Notes
+
+Use this as the final step before AgentReacher schedules posts. It turns strategy, drafts, and calendar slots into a reviewable queue.
+
+Example usage in AgentReacher: "Package these 18 campaign posts for scheduling next month and flag anything that needs approval."

--- a/skills/agentreacher/skills/post-packager/agents/openai.yaml
+++ b/skills/agentreacher/skills/post-packager/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Post Packager"
+  short_description: "Prepare posts for approval and scheduling"
+  default_prompt: "Use $post-packager to turn these drafts into an approval-ready scheduling package."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/repurpose/SKILL.md
+++ b/skills/agentreacher/skills/repurpose/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: repurpose
+description: Repurpose one source asset into platform-specific social media posts while preserving the original idea and adapting format, tone, and call to action. Use when turning blogs, transcripts, changelogs, podcasts, videos, demos, notes, or launch plans into a social content package.
+tags:
+  - social-media
+  - content-repurposing
+  - campaigns
+  - agentreacher-compatible
+---
+
+# Repurpose
+
+Turn one source asset into a compact campaign package. The goal is not to summarize everywhere. The goal is to extract the strongest ideas and make each platform feel native.
+
+## Inputs
+
+- source asset: pasted text, URL summary, transcript, changelog, feature note, launch plan, or rough idea
+- target platforms
+- audience segment
+- campaign goal
+- brand voice constraints
+- hard facts that must remain accurate
+- claims to avoid
+
+If the source is long, first extract a reusable idea inventory.
+
+## Idea Inventory
+
+Pull out the core promise, 3-7 atomic ideas, proof points, story moments, objections, reusable phrases, visual opportunities, and calls to action. Discard weak ideas before creating posts. Repurposing should make a campaign sharper, not larger.
+
+## Workflow
+
+1. Map the source into campaign angles:
+   educational, founder story, product demo, objection handling, proof, and contrast.
+
+2. Select platform formats:
+   X post/thread, Instagram post/reel/carousel, Facebook post, LinkedIn narrative/list, TikTok short-form video, YouTube Short, Pinterest pin, Threads sequence, and Bluesky post.
+
+3. Write channel-native drafts:
+   give each post a distinct angle, reuse facts rather than wording, adapt CTA intensity to platform norms, and keep proof visible.
+
+4. Build a simple schedule:
+   launch/publish day, 2 follow-up posts, 1 objection-handling post, and 1 proof or demo post.
+
+5. Add reuse notes:
+   visual asset, schedule-ready status, and human approval needs.
+
+## Quality Bar
+
+- No generic "excited to announce" unless it is intentionally undercut by a strong second line.
+- No identical cross-posting except for very short announcements.
+- No inflated claims beyond the source.
+- Each platform draft should make sense even if seen in isolation.
+- The campaign should have sequence logic: introduce, deepen, prove, remind.
+
+## Output Format
+
+```md
+## Source Distillation
+- Core idea:
+- Best proof:
+- Audience tension:
+- Campaign goal:
+## Content Package
+### X
+[drafts]
+### LinkedIn
+[drafts]
+### Short-form Video
+[hook, beats, caption]
+## Schedule
+| Timing | Platform | Angle | Asset | Status |
+| --- | --- | --- | --- | --- |
+## Approval Notes
+- [fact/claim needing review]
+```
+
+## AgentReacher Notes
+
+Compatible with AgentReacher autonomous posting pipelines. Use this skill before scheduling so the campaign enters the calendar as platform-specific posts instead of duplicated copy.
+
+Example usage in AgentReacher: "Repurpose this changelog into a one-week launch campaign for X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Pinterest, Threads, and Bluesky."

--- a/skills/agentreacher/skills/repurpose/agents/openai.yaml
+++ b/skills/agentreacher/skills/repurpose/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Repurpose"
+  short_description: "Turn source assets into social campaigns"
+  default_prompt: "Use $repurpose to turn this source asset into a platform-specific social content package."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/agentreacher/skills/viral-hooks/SKILL.md
+++ b/skills/agentreacher/skills/viral-hooks/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: viral-hooks
+description: Generate platform-native hooks optimized for engagement, curiosity, and audience tension. Use when creating social media hooks, launch post openings, thread starters, video intros, founder story angles, or campaign first lines.
+tags:
+  - social-media
+  - hooks
+  - copywriting
+  - agentreacher-compatible
+---
+
+# Viral Hooks
+
+Create hooks that make the right audience want the next sentence. Do not chase generic virality. Optimize for relevance, tension, credibility, and platform fit.
+
+## Inputs
+
+- audience: who should care
+- platform: X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Pinterest, Threads, or Bluesky
+- asset: product, announcement, idea, story, opinion, data point, demo, or lesson
+- desired action: read, reply, click, follow, share, try, join waitlist, or book demo
+- proof: screenshot, metric, user quote, failure, before/after, demo, or specific experience
+
+If no platform is provided, produce hooks for X and LinkedIn by default.
+
+## Taste Rules
+
+- Lead with a specific tension, not a category claim.
+- Make the reader feel "this is about my problem" before asking for attention.
+- Prefer concrete nouns, numbers, stakes, and tradeoffs.
+- Avoid fake contrarianism, engagement bait, vague inspiration, and "game changer" language.
+- Do not overpromise. A hook should create curiosity the post can satisfy.
+- Do not use hashtags unless the user asks.
+
+## Workflow
+
+1. Identify the strongest tension:
+   pain, surprise, status, proof, urgency.
+
+2. Pick hook families:
+   observation, confession, result, teardown, behind-the-scenes, warning, open loop.
+
+3. Generate in batches:
+   10 hooks for the primary platform, 5 safer variants, 5 sharper variants, and 3 anti-hooks to avoid.
+
+4. Score the best hooks from 1-5 on:
+   audience specificity, curiosity, credibility, platform fit, and follow-through potential.
+
+5. Return the top 5 with one-line rationale and the post angle each hook implies.
+
+## Platform Adjustments
+
+- X: compressed, opinionated, high information density.
+- Instagram: visual-first, caption supports the creative instead of carrying all context.
+- Facebook: accessible, conversational, clear enough for broader mixed audiences.
+- LinkedIn: clear professional stakes, less irony, more context.
+- TikTok/YouTube: first 1-2 seconds must be visual or spoken plainly.
+- Pinterest: outcome-led, searchable, and tied to a concrete visual promise.
+- Threads: conversational, casual, founder/personality-led.
+- Bluesky: concise, specific, and less sales-coded.
+
+## Output Format
+
+```md
+## Recommended Hooks
+1. "[hook]"
+   Angle: [post angle]
+   Why it works: [one sentence]
+   Score: [x]/25
+## Safer Variants
+...
+## Sharper Variants
+...
+## Avoid
+- "[anti-hook]" - [why]
+```
+
+## AgentReacher Notes
+
+This skill works well inside AgentReacher campaign workflows where one product moment becomes scheduled variants across X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Pinterest, Threads, and Bluesky.
+
+Example usage in AgentReacher: "Create hooks for a launch campaign announcing autonomous social posting from ChatGPT and Claude."

--- a/skills/agentreacher/skills/viral-hooks/agents/openai.yaml
+++ b/skills/agentreacher/skills/viral-hooks/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Viral Hooks"
+  short_description: "Create platform-native social hooks"
+  default_prompt: "Use $viral-hooks to create platform-native hooks for this campaign."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
Adds the AgentReacher social campaign skill pack to SkillHub.\n\nSource repo: https://github.com/agentreacher/skills\nInstall all skills: `npx skills add agentreacher/skills --all`\n\nIncluded skills:\n- content-pillars\n- cadence-planner\n- calendar-builder\n- viral-hooks\n- repurpose\n- positioning\n- post-packager\n\nValidation: ran `npx skills@latest add . --list` locally and confirmed the added skills are discoverable.