### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #76)

### DIFF
--- a/skills/Harmeet10000/skills/create_PRD/SKILL.md
+++ b/skills/Harmeet10000/skills/create_PRD/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Create a Product Requirements Document from conversation
-argument-hint: [output-filename]
+argument-hint: "[output-filename]"
 ---
 
 # Create PRD: Generate Product Requirements Document

--- a/skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/references/advanced-features.md
+++ b/skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/references/advanced-features.md
@@ -190,7 +190,7 @@ Provide a detailed report with severity levels and specific fixes.
 ```markdown
 <!-- .claude/commands/review-pr.md -->
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 description: Review pull request with code-reviewer agent
 allowed-tools: Bash(gh:*), Read
 ---
@@ -578,7 +578,7 @@ When invoked:
 ```markdown
 <!-- .claude/commands/full-feature.md -->
 ---
-argument-hint: [feature-description]
+argument-hint: "[feature-description]"
 description: Complete feature development pipeline
 ---
 

--- a/skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/research/slash-commands.md
+++ b/skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/research/slash-commands.md
@@ -43,7 +43,7 @@ Analyze this code for performance issues and suggest optimizations.
 ```markdown
 ---
 description: Create a git commit
-argument-hint: [message]
+argument-hint: "[message]"
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
 model: claude-3-5-haiku-20241022
 disable-model-invocation: false
@@ -82,7 +82,7 @@ Fix issue #$ARGUMENTS following our coding standards
 
 ```markdown
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 description: Review pull request
 ---
 
@@ -195,7 +195,7 @@ EOF
 ```bash
 cat > .claude/commands/commit.md << 'EOF'
 ---
-argument-hint: [message]
+argument-hint: "[message]"
 description: Create a git commit
 ---
 
@@ -1367,7 +1367,7 @@ fi
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Bash(git:*), Read
 model: claude-3-5-sonnet-20241022
 ---

--- a/skills/aiskillstore/marketplace/anthropics/command-development/README.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/aiskillstore/marketplace/anthropics/command-development/SKILL.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -774,7 +774,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/aiskillstore/marketplace/anthropics/command-development/examples/plugin-commands.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/aiskillstore/marketplace/anthropics/command-development/examples/simple-commands.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/aiskillstore/marketplace/anthropics/command-development/references/advanced-workflows.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/aiskillstore/marketplace/anthropics/command-development/references/documentation-patterns.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/aiskillstore/marketplace/anthropics/command-development/references/frontmatter-reference.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/aiskillstore/marketplace/anthropics/command-development/references/interactive-commands.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/aiskillstore/marketplace/anthropics/command-development/references/plugin-features-reference.md
+++ b/skills/aiskillstore/marketplace/anthropics/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/skills/aiskillstore/marketplace/byronwilliamscpa/project-planning/workflows/synthesize.md
+++ b/skills/aiskillstore/marketplace/byronwilliamscpa/project-planning/workflows/synthesize.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: [--start-phase]
+argument-hint: "[--start-phase]"
 description: Synthesize 4 planning documents into comprehensive PROJECT-PLAN.md with git branch strategy
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*), TodoWrite
 ---

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/SKILL.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/SKILL.md
@@ -48,7 +48,7 @@ description: Brief description of what the command does
 ---
 description: Brief description of what the command does
 allowed-tools: Read, Grep, Glob, Bash
-argument-hint: [parameter-description]
+argument-hint: "[parameter-description]"
 ---
 ```
 
@@ -57,7 +57,7 @@ argument-hint: [parameter-description]
 ---
 description: Brief description of command functionality            # Required
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash               # Optional: Pre-approved tools
-argument-hint: [filename] [options]                               # Optional: Parameter guide for users
+argument-hint: "[filename] [options]                               # Optional: Parameter guide for users"
 model: claude-3-5-haiku-20241022                                  # Optional: Specific model (see warning below)
 disable-model-invocation: false                                   # Optional: Prevent auto-invocation
 ---
@@ -175,7 +175,7 @@ Commands support special variables for arguments:
 ---
 description: One-line description of what this command does
 allowed-tools: Read, Grep, Bash
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 # Command Name
@@ -287,7 +287,7 @@ python3 validate-command.py .claude/commands/run-tests.md
 
 ### Pattern 1: Single Argument
 ```yaml
-argument-hint: [filename]
+argument-hint: "[filename]"
 ```
 
 Body:
@@ -299,7 +299,7 @@ Usage: `/process-file data.csv`
 
 ### Pattern 2: Multiple Arguments
 ```yaml
-argument-hint: [source] [destination]
+argument-hint: "[source] [destination]"
 ```
 
 Body:
@@ -311,7 +311,7 @@ Usage: `/copy-file src.txt dest.txt`
 
 ### Pattern 3: Flexible Arguments
 ```yaml
-argument-hint: [search-term] [optional-path]
+argument-hint: "[search-term] [optional-path]"
 ```
 
 Body:
@@ -323,7 +323,7 @@ Usage: `/search "error" ./src` or `/search "error"`
 
 ### Pattern 4: All Arguments
 ```yaml
-argument-hint: [commit-message]
+argument-hint: "[commit-message]"
 ```
 
 Body:
@@ -373,7 +373,7 @@ Use for: Complete workflows (test + commit + push)
 ---
 description: Commit changes and push to remote
 allowed-tools: Read, Grep, Bash
-argument-hint: [commit-message]
+argument-hint: "[commit-message]"
 ---
 
 # Git Commit and Push
@@ -397,7 +397,7 @@ Usage: `/git-commit-push Add authentication feature`
 ---
 description: Review a pull request for quality and security
 allowed-tools: Read, Grep, Bash
-argument-hint: [PR-number]
+argument-hint: "[PR-number]"
 ---
 
 # Review Pull Request
@@ -418,7 +418,7 @@ Usage: `/review-pr 123`
 ---
 description: Run specific test suite and report results
 allowed-tools: Read, Grep, Bash
-argument-hint: [test-path]
+argument-hint: "[test-path]"
 ---
 
 # Run Tests
@@ -438,7 +438,7 @@ Usage: `/run-tests ./tests/unit`
 ---
 description: Create a new React component with tests
 allowed-tools: Read, Write, Grep, Glob
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 # Create React Component
@@ -458,7 +458,7 @@ Usage: `/create-component UserProfile`
 ---
 description: Generate API documentation from code
 allowed-tools: Read, Write, Grep, Glob, Bash
-argument-hint: [source-directory]
+argument-hint: "[source-directory]"
 ---
 
 # Generate API Docs

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-migration-guide.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-migration-guide.md
@@ -82,7 +82,7 @@ model: claude-haiku-4-5
 argument-hint: filename options
 
 # After
-argument-hint: [filename] [options]
+argument-hint: "[filename] [options]"
 ```
 
 ---
@@ -176,7 +176,7 @@ Open command file and update YAML:
 description: [new description]
 allowed-tools: [updated tools]
 model: [version alias]
-argument-hint: [bracketed hint]
+argument-hint: "[bracketed hint]"
 ---
 ```
 

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-update-patterns.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-update-patterns.md
@@ -256,7 +256,7 @@ description: Process a file
 # After
 ---
 description: Process a file
-argument-hint: [filename]
+argument-hint: "[filename]"
 ---
 ```
 
@@ -281,7 +281,7 @@ argument-hint: filename options
 
 # After
 ---
-argument-hint: [filename] [options]
+argument-hint: "[filename] [options]"
 ---
 ```
 

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/references/plugin-architecture-guide.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/references/plugin-architecture-guide.md
@@ -126,7 +126,7 @@ description: Expert at security reviews. Auto-invokes when reviewing code or ana
 ```yaml
 ---
 description: Run security scan on specified file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 ```
 

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/minimal-plugin-template/commands/example.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/minimal-plugin-template/commands/example.md
@@ -1,7 +1,7 @@
 ---
 description: Example command that demonstrates plugin functionality
 allowed-tools: Read, Grep, Glob
-argument-hint: [optional-arg]
+argument-hint: "[optional-arg]"
 ---
 
 # Example Command

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/analyze.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/analyze.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze the specified component and provide recommendations
 allowed-tools: Read, Grep, Glob, Bash
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 # Analyze Command

--- a/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/fix.md
+++ b/skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/fix.md
@@ -1,7 +1,7 @@
 ---
 description: Fix identified issues in the specified component
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 # Fix Command

--- a/skills/aiskillstore/marketplace/command-development/README.md
+++ b/skills/aiskillstore/marketplace/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/aiskillstore/marketplace/command-development/SKILL.md
+++ b/skills/aiskillstore/marketplace/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -774,7 +774,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/aiskillstore/marketplace/command-development/examples/plugin-commands.md
+++ b/skills/aiskillstore/marketplace/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/aiskillstore/marketplace/command-development/examples/simple-commands.md
+++ b/skills/aiskillstore/marketplace/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/aiskillstore/marketplace/command-development/references/advanced-workflows.md
+++ b/skills/aiskillstore/marketplace/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/aiskillstore/marketplace/command-development/references/documentation-patterns.md
+++ b/skills/aiskillstore/marketplace/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/aiskillstore/marketplace/command-development/references/frontmatter-reference.md
+++ b/skills/aiskillstore/marketplace/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/aiskillstore/marketplace/command-development/references/interactive-commands.md
+++ b/skills/aiskillstore/marketplace/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/aiskillstore/marketplace/command-development/references/plugin-features-reference.md
+++ b/skills/aiskillstore/marketplace/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/skills/aiskillstore/marketplace/davila7/command-development/README.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/skills/aiskillstore/marketplace/davila7/command-development/SKILL.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -774,7 +774,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/skills/aiskillstore/marketplace/davila7/command-development/examples/plugin-commands.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/skills/aiskillstore/marketplace/davila7/command-development/examples/simple-commands.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/skills/aiskillstore/marketplace/davila7/command-development/references/advanced-workflows.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/skills/aiskillstore/marketplace/davila7/command-development/references/documentation-patterns.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/skills/aiskillstore/marketplace/davila7/command-development/references/frontmatter-reference.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/skills/aiskillstore/marketplace/davila7/command-development/references/interactive-commands.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/skills/aiskillstore/marketplace/davila7/command-development/references/plugin-features-reference.md
+++ b/skills/aiskillstore/marketplace/davila7/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/skills/aiskillstore/marketplace/emz1998/command-management/references/command-docs.md
+++ b/skills/aiskillstore/marketplace/emz1998/command-management/references/command-docs.md
@@ -183,7 +183,7 @@ For example:
 ```markdown
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
-argument-hint: [message]
+argument-hint: "[message]"
 description: Create a git commit
 model: claude-3-5-haiku-20241022
 ---
@@ -195,7 +195,7 @@ Example using positional arguments:
 
 ```markdown
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 description: Review pull request
 ---
 

--- a/skills/aiskillstore/marketplace/humanizerai/detect-ai/SKILL.md
+++ b/skills/aiskillstore/marketplace/humanizerai/detect-ai/SKILL.md
@@ -2,7 +2,7 @@
 name: detect-ai
 description: Analyze text to detect if it was written by AI. Returns a score from 0-100 with detailed metrics. Use when checking content before publishing or submitting.
 user-invocable: true
-argument-hint: [text to analyze]
+argument-hint: "[text to analyze]"
 allowed-tools: WebFetch
 ---
 

--- a/skills/aiskillstore/marketplace/pbakaus/arrange/SKILL.md
+++ b/skills/aiskillstore/marketplace/pbakaus/arrange/SKILL.md
@@ -2,7 +2,7 @@
 name: arrange
 description: Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy to create intentional compositions.
 user-invocable: true
-argument-hint: [TARGET=<value>]
+argument-hint: "[TARGET=<value>]"
 ---
 
 Assess and improve layout and spacing that feels monotonous, crowded, or structurally weak — turning generic arrangements into intentional, rhythmic compositions.

--- a/skills/aiskillstore/marketplace/pbakaus/overdrive/SKILL.md
+++ b/skills/aiskillstore/marketplace/pbakaus/overdrive/SKILL.md
@@ -2,7 +2,7 @@
 name: overdrive
 description: Push interfaces past conventional limits with technically ambitious implementations. Whether that's a shader, a 60fps virtual table, spring physics on a dialog, or scroll-driven reveals — make users ask "how did they do that?"
 user-invocable: true
-argument-hint: [TARGET=<value>]
+argument-hint: "[TARGET=<value>]"
 ---
 
 Start your response with:

--- a/skills/aiskillstore/marketplace/pbakaus/typeset/SKILL.md
+++ b/skills/aiskillstore/marketplace/pbakaus/typeset/SKILL.md
@@ -2,7 +2,7 @@
 name: typeset
 description: Improve typography by fixing font choices, hierarchy, sizing, weight consistency, and readability. Makes text feel intentional and polished.
 user-invocable: true
-argument-hint: [TARGET=<value>]
+argument-hint: "[TARGET=<value>]"
 ---
 
 Assess and improve typography that feels generic, inconsistent, or poorly structured — turning default-looking text into intentional, well-crafted type.

--- a/skills/aiskillstore/marketplace/sickn33/daily-news-report/SKILL.md
+++ b/skills/aiskillstore/marketplace/sickn33/daily-news-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-news-report
 description: Scrapes content based on a preset URL list, filters high-quality technical information, and generates daily Markdown reports.
-argument-hint: [optional: date]
+argument-hint: "[optional: date]"
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: Task, WebFetch, Read, Write, Bash(mkdir*), Bash(date*), Bash(ls*), mcp__chrome-devtools__*

--- a/skills/aiskillstore/marketplace/softaworks/command-creator/references/best-practices.md
+++ b/skills/aiskillstore/marketplace/softaworks/command-creator/references/best-practices.md
@@ -85,7 +85,7 @@ Use this template structure for comprehensive commands:
 ```markdown
 ---
 description: [One-line description for /help output]
-argument-hint: [<required>] or [[optional]] (omit if no arguments)
+argument-hint: "[<required>] or [[optional]] (omit if no arguments)"
 ---
 
 # [Command Title]

--- a/skills/aiskillstore/marketplace/softaworks/command-creator/references/examples.md
+++ b/skills/aiskillstore/marketplace/softaworks/command-creator/references/examples.md
@@ -458,7 +458,7 @@ The goal is to create a comprehensive implementation plan that will be saved as 
 ```markdown
 ---
 description: Perform a local code review using repository standards and best practices
-argument-hint: [base-branch]
+argument-hint: "[base-branch]"
 ---
 
 # Codex Review

--- a/skills/alirezarezvani/claude-code-skill-factory/slash-command-factory/SKILL.md
+++ b/skills/alirezarezvani/claude-code-skill-factory/slash-command-factory/SKILL.md
@@ -441,7 +441,7 @@ After collecting answers:
 ```yaml
 ---
 description: [From command purpose]
-argument-hint: [If $ARGUMENTS needed]
+argument-hint: "[If $ARGUMENTS needed]"
 allowed-tools: [From tool selection]
 model: [If specified]
 ---
@@ -510,7 +510,7 @@ To install:
 ```yaml
 ---
 description: Comprehensive business and market research with competitor analysis
-argument-hint: [company/market] [industry]
+argument-hint: "[company/market] [industry]"
 allowed-tools: Read, Bash, Grep
 ---
 ```
@@ -534,7 +534,7 @@ allowed-tools: Read, Bash, Grep
 ```yaml
 ---
 description: Multi-platform content trend analysis for data-driven content strategy
-argument-hint: [topic] [platforms]
+argument-hint: "[topic] [platforms]"
 allowed-tools: Read, Bash
 ---
 ```
@@ -558,7 +558,7 @@ allowed-tools: Read, Bash
 ```yaml
 ---
 description: Translate medical terminology to 8th-10th grade reading level (German/English)
-argument-hint: [medical-term] [de|en]
+argument-hint: "[medical-term] [de|en]"
 allowed-tools: Read
 ---
 ```
@@ -582,7 +582,7 @@ allowed-tools: Read
 ```yaml
 ---
 description: Audit code for HIPAA/GDPR/DSGVO compliance requirements
-argument-hint: [code-path] [hipaa|gdpr|dsgvo|all]
+argument-hint: "[code-path] [hipaa|gdpr|dsgvo|all]"
 allowed-tools: Read, Grep, Task
 ---
 ```
@@ -606,7 +606,7 @@ allowed-tools: Read, Grep, Task
 ```yaml
 ---
 description: Generate complete API client with error handling and tests
-argument-hint: [api-name] [endpoints]
+argument-hint: "[api-name] [endpoints]"
 allowed-tools: Read, Write, Edit, Bash, Task
 ---
 ```
@@ -630,7 +630,7 @@ allowed-tools: Read, Write, Edit, Bash, Task
 ```yaml
 ---
 description: Auto-generate comprehensive test suite with coverage analysis
-argument-hint: [file-path] [unit|integration|e2e]
+argument-hint: "[file-path] [unit|integration|e2e]"
 allowed-tools: Read, Write, Bash
 ---
 ```
@@ -654,7 +654,7 @@ allowed-tools: Read, Write, Bash
 ```yaml
 ---
 description: Auto-generate documentation from code (API docs, README, architecture)
-argument-hint: [code-path] [api|readme|architecture|all]
+argument-hint: "[code-path] [api|readme|architecture|all]"
 allowed-tools: Read, Write, Grep
 ---
 ```
@@ -678,7 +678,7 @@ allowed-tools: Read, Write, Grep
 ```yaml
 ---
 description: Extract and structure knowledge from documents into actionable insights
-argument-hint: [doc-path] [faq|summary|kb|all]
+argument-hint: "[doc-path] [faq|summary|kb|all]"
 allowed-tools: Read, Grep
 ---
 ```
@@ -702,7 +702,7 @@ allowed-tools: Read, Grep
 ```yaml
 ---
 description: Analyze workflows and provide optimization recommendations
-argument-hint: [workflow-description]
+argument-hint: "[workflow-description]"
 allowed-tools: Read, Task
 ---
 ```
@@ -726,7 +726,7 @@ allowed-tools: Read, Task
 ```yaml
 ---
 description: Launch and coordinate multiple agents for complex tasks
-argument-hint: [agent-names] [task-description]
+argument-hint: "[agent-names] [task-description]"
 allowed-tools: Task
 ---
 ```
@@ -825,7 +825,7 @@ Create a custom command for analyzing customer feedback and generating product i
 ```markdown
 ---
 description: Brief description of what the command does
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Write, Bash
 model: claude-3-5-sonnet-20241022
 ---

--- a/skills/daymade/claude-code-skills/asr-transcribe-to-text/SKILL.md
+++ b/skills/daymade/claude-code-skills/asr-transcribe-to-text/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: asr-transcribe-to-text
 description: Transcribe audio and video files to text using a remote ASR service (Qwen3-ASR or OpenAI-compatible endpoint). Extracts audio from video, sends to configurable ASR endpoint, outputs clean text. Use when the user wants to transcribe recordings, convert audio/video to text, do speech-to-text, or mentions ASR, Qwen ASR, 转录, 语音转文字, 录音转文字, or has a meeting recording, lecture, interview, or screen recording to transcribe.
-argument-hint: [audio-or-video-file-path]
+argument-hint: "[audio-or-video-file-path]"
 ---
 
 # ASR Transcribe to Text

--- a/skills/daymade/claude-code-skills/competitors-analysis/SKILL.md
+++ b/skills/daymade/claude-code-skills/competitors-analysis/SKILL.md
@@ -3,7 +3,7 @@ name: competitors-analysis
 description: Analyze competitor repositories with evidence-based approach. Use when tracking competitors, creating competitor profiles, or generating competitive analysis. CRITICAL - all analysis must be based on actual cloned code, never assumptions. Triggers include "analyze competitor", "add competitor", "competitive analysis", or "竞品分析".
 context: fork
 agent: general-purpose
-argument-hint: [product-name] [competitor-url]
+argument-hint: "[product-name] [competitor-url]"
 ---
 
 # Competitors Analysis

--- a/skills/daymade/claude-code-skills/continue-claude-work/SKILL.md
+++ b/skills/daymade/claude-code-skills/continue-claude-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: continue-claude-work
 description: Recover actionable context from local `.claude` session artifacts and continue interrupted work without running `claude --resume`. This skill should be used when the user provides a Claude session ID, asks to continue prior work from local history, or wants to inspect `.claude` files before resuming implementation.
-argument-hint: [session-id]
+argument-hint: "[session-id]"
 ---
 
 # Continue Claude Work

--- a/skills/daymade/claude-code-skills/product-analysis/SKILL.md
+++ b/skills/daymade/claude-code-skills/product-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-analysis
 description: Multi-path parallel product analysis with cross-model test-time compute scaling. Spawns parallel agents (Claude Code agent teams + Codex CLI) to explore product from multiple perspectives, then synthesizes findings into actionable optimization plans. Can invoke competitors-analysis for competitive benchmarking. Use when "product audit", "self-review", "发布前审查", "产品分析", "analyze our product", "UX audit", or "信息架构审计".
-argument-hint: [scope: full|ux|api|arch|compare]
+argument-hint: "[scope: full|ux|api|arch|compare]"
 ---
 
 # Product Analysis

--- a/skills/daymade/claude-code-skills/skill-creator/SKILL.md
+++ b/skills/daymade/claude-code-skills/skill-creator/SKILL.md
@@ -187,7 +187,7 @@ name: my-skill
 description: What this skill does and when to use it. Use when...
 context: fork
 agent: general-purpose
-argument-hint: [topic]
+argument-hint: "[topic]"
 ---
 ```
 
@@ -300,7 +300,7 @@ Step 0: Check available tools
   - `which docker` → If found, enable container-based execution
 
 # Bad: Manual flags
-argument-hint: [scope] [--with-codex] [--docker] [--verbose]
+argument-hint: "[scope] [--with-codex] [--docker] [--verbose]"
 ```
 
 **Principle:** Capabilities auto-detect, user decides scope. A skill should discover what it CAN do and act accordingly, not require users to remember what tools are installed.

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/builder/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/builder/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(npm:*), Bash(node:*)
-argument-hint: [what to build]
+argument-hint: "[what to build]"
 compatible-with: claude-code
 tags: [productivity, dashboard, builder]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/competitor-analyst/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/competitor-analyst/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [competitor or market]
+argument-hint: "[competitor or market]"
 compatible-with: claude-code
 tags: [productivity, competitor-analyst]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/data-analyst/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/data-analyst/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(node:*)
-argument-hint: [metric or question]
+argument-hint: "[metric or question]"
 compatible-with: claude-code
 tags: [productivity, database, dashboard]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/devil-advocate/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/devil-advocate/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [idea or proposal to challenge]
+argument-hint: "[idea or proposal to challenge]"
 compatible-with: claude-code
 tags: [productivity, testing, devil-advocate]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/hypothesis-tester/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/hypothesis-tester/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [assumption or experiment]
+argument-hint: "[assumption or experiment]"
 compatible-with: claude-code
 tags: [productivity, testing, hypothesis-tester]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/product-brief/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/product-brief/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [feature name]
+argument-hint: "[feature name]"
 compatible-with: claude-code
 tags: [productivity, product-brief]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/stakeholder-update/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/stakeholder-update/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [project or team]
+argument-hint: "[project or team]"
 compatible-with: claude-code
 tags: [productivity, stakeholder-update]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/strategic-clarity/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/strategic-clarity/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [phase: absorb/audit/articulate/align]
+argument-hint: "[phase: absorb/audit/articulate/align]"
 compatible-with: claude-code
 tags: [productivity, workflow, strategic-clarity]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/technical-analyst/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/technical-analyst/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(git:*)
-argument-hint: [system, service, or file]
+argument-hint: "[system, service, or file]"
 compatible-with: claude-code
 tags: [productivity, technical-analyst]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/thought-partner/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/thought-partner/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [topic or question]
+argument-hint: "[topic or question]"
 compatible-with: claude-code
 tags: [productivity, thought-partner]
 

--- a/skills/jeremylongshore/claude-code-plugins-plus-skills/writer/SKILL.md
+++ b/skills/jeremylongshore/claude-code-plugins-plus-skills/writer/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint: [document type or topic]
+argument-hint: "[document type or topic]"
 compatible-with: claude-code
 tags: [productivity, writer]
 


### PR DESCRIPTION
Closes #76.

## Summary

Purely mechanical single-character transform to 63 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (63)

- `skills/aiskillstore/marketplace/byronwilliamscpa/project-planning/workflows/synthesize.md`
- `skills/aiskillstore/marketplace/softaworks/command-creator/references/best-practices.md`
- `skills/aiskillstore/marketplace/command-development/SKILL.md`
- `skills/aiskillstore/marketplace/humanizerai/detect-ai/SKILL.md`
- `skills/aiskillstore/marketplace/davila7/command-development/SKILL.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/SKILL.md`
- `skills/aiskillstore/marketplace/command-development/README.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/SKILL.md`
- `skills/Harmeet10000/skills/create_PRD/SKILL.md`
- `skills/aiskillstore/marketplace/command-development/examples/plugin-commands.md`
- `skills/aiskillstore/marketplace/command-development/examples/simple-commands.md`
- `skills/aiskillstore/marketplace/davila7/command-development/README.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/README.md`
- `skills/alirezarezvani/claude-code-skill-factory/slash-command-factory/SKILL.md`
- `skills/aiskillstore/marketplace/command-development/references/frontmatter-reference.md`
- `skills/aiskillstore/marketplace/davila7/command-development/examples/simple-commands.md`
- `skills/aiskillstore/marketplace/davila7/command-development/examples/plugin-commands.md`
- `skills/aiskillstore/marketplace/command-development/references/advanced-workflows.md`
- `skills/aiskillstore/marketplace/pbakaus/typeset/SKILL.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/examples/simple-commands.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/examples/plugin-commands.md`
- `skills/aiskillstore/marketplace/command-development/references/plugin-features-reference.md`
- `skills/aiskillstore/marketplace/pbakaus/arrange/SKILL.md`
- `skills/aiskillstore/marketplace/davila7/command-development/references/frontmatter-reference.md`
- `skills/aiskillstore/marketplace/davila7/command-development/references/advanced-workflows.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/references/frontmatter-reference.md`
- `skills/aiskillstore/marketplace/davila7/command-development/references/plugin-features-reference.md`
- `skills/aiskillstore/marketplace/pbakaus/overdrive/SKILL.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/references/advanced-workflows.md`
- `skills/daymade/claude-code-skills/competitors-analysis/SKILL.md`
- `skills/daymade/claude-code-skills/product-analysis/SKILL.md`
- `skills/daymade/claude-code-skills/continue-claude-work/SKILL.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/references/plugin-features-reference.md`
- `skills/daymade/claude-code-skills/asr-transcribe-to-text/SKILL.md`
- `skills/daymade/claude-code-skills/skill-creator/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/writer/SKILL.md`
- `skills/aiskillstore/marketplace/sickn33/daily-news-report/SKILL.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/fix.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/thought-partner/SKILL.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/minimal-plugin-template/commands/example.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/builder/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/devil-advocate/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/product-brief/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/data-analyst/SKILL.md`
- `skills/aiskillstore/marketplace/command-development/references/documentation-patterns.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/technical-analyst/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/strategic-clarity/SKILL.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/hypothesis-tester/SKILL.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/templates/standard-plugin-template/commands/analyze.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/stakeholder-update/SKILL.md`
- `skills/aiskillstore/marketplace/emz1998/command-management/references/command-docs.md`
- `skills/jeremylongshore/claude-code-plugins-plus-skills/competitor-analyst/SKILL.md`
- `skills/aiskillstore/marketplace/davila7/command-development/references/documentation-patterns.md`
- `skills/aiskillstore/marketplace/softaworks/command-creator/references/examples.md`
- `skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/research/slash-commands.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/references/documentation-patterns.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-update-patterns.md`
- `skills/aiskillstore/marketplace/aaronabuusama/subagent-factory/references/advanced-features.md`
- `skills/aiskillstore/marketplace/command-development/references/interactive-commands.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-commands/references/command-migration-guide.md`
- `skills/aiskillstore/marketplace/davila7/command-development/references/interactive-commands.md`
- `skills/aiskillstore/marketplace/anthropics/command-development/references/interactive-commands.md`
- `skills/aiskillstore/marketplace/c0ntr0lledcha0s/building-plugins/references/plugin-architecture-guide.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
